### PR TITLE
Add domain models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /.idea/assetWizardSettings.xml
 .DS_Store
 /build
+**/build
 /captures
 .externalNativeBuild
 .cxx

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,7 +46,9 @@ tasks.withType<KotlinJvmCompile>().configureEach {
     }
 }
 
-dependencies {
+    dependencies {
+
+    implementation(project(":domain"))
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
@@ -63,4 +65,4 @@ dependencies {
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
-}
+    }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,4 +3,5 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
+    alias(libs.plugins.kotlin.jvm) apply false
 }

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -1,0 +1,5 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+}
+
+

--- a/domain/src/main/kotlin/io/embrace/shoppingcart/domain/CartItem.kt
+++ b/domain/src/main/kotlin/io/embrace/shoppingcart/domain/CartItem.kt
@@ -1,0 +1,9 @@
+package io.embrace.shoppingcart.domain
+
+/**
+ * A quantity of a particular product in the shopping cart.
+ */
+data class CartItem(
+    val product: Product,
+    val quantity: Int,
+)

--- a/domain/src/main/kotlin/io/embrace/shoppingcart/domain/CartSummary.kt
+++ b/domain/src/main/kotlin/io/embrace/shoppingcart/domain/CartSummary.kt
@@ -1,0 +1,9 @@
+package io.embrace.shoppingcart.domain
+
+/**
+ * Overview of the shopping cart's contents and total price.
+ */
+data class CartSummary(
+    val items: List<CartItem>,
+    val totalPrice: Double,
+)

--- a/domain/src/main/kotlin/io/embrace/shoppingcart/domain/Product.kt
+++ b/domain/src/main/kotlin/io/embrace/shoppingcart/domain/Product.kt
@@ -1,0 +1,12 @@
+package io.embrace.shoppingcart.domain
+
+/**
+ * Represents an item available for purchase.
+ */
+data class Product(
+    val id: String,
+    val name: String,
+    val description: String,
+    val price: Double,
+    val imageUrl: String,
+)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,4 +29,5 @@ androidx-material3 = { group = "androidx.compose.material3", name = "material3" 
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,3 +21,4 @@ dependencyResolutionManagement {
 
 rootProject.name = "Embrace Shopping Cart"
 include(":app")
+include(":domain")


### PR DESCRIPTION
## Summary
- add Kotlin-only `domain` module
- introduce Product, CartItem and CartSummary data classes
- wire app module to depend on new domain layer

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew :domain:test`


------
https://chatgpt.com/codex/tasks/task_e_68937aee0b0c8333ae1e0addcdcfb6a6