### PR TITLE
Add mock data service with network simulation and auth state

### DIFF
--- a/app/src/main/assets/products.json
+++ b/app/src/main/assets/products.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "1",
+    "name": "T-Shirt",
+    "priceCents": 1999,
+    "description": "Soft cotton t-shirt",
+    "imageUrl": "tshirt.png"
+  },
+  {
+    "id": "2",
+    "name": "Jeans",
+    "priceCents": 4999,
+    "description": "Classic blue jeans",
+    "imageUrl": "jeans.png"
+  },
+  {
+    "id": "3",
+    "name": "Sneakers",
+    "priceCents": 6999,
+    "description": "Comfortable running sneakers",
+    "imageUrl": "sneakers.png"
+  }
+]

--- a/app/src/main/java/io/embrace/shoppingcart/data/local/AppDatabase.kt
+++ b/app/src/main/java/io/embrace/shoppingcart/data/local/AppDatabase.kt
@@ -12,7 +12,7 @@ import androidx.room.RoomDatabase
                         PaymentMethodEntity::class,
                         CartItemEntity::class,
                         OrderEntity::class],
-        version = 2,
+        version = 3,
         exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/app/src/main/java/io/embrace/shoppingcart/data/local/ProductEntity.kt
+++ b/app/src/main/java/io/embrace/shoppingcart/data/local/ProductEntity.kt
@@ -7,7 +7,9 @@ import androidx.room.PrimaryKey
 data class ProductEntity(
     @PrimaryKey val id: String,
     val name: String,
-    val priceCents: Int
+    val priceCents: Int,
+    val description: String,
+    val imageUrl: String
 )
 
 

--- a/app/src/main/java/io/embrace/shoppingcart/data/repository/ProductRepositoryImpl.kt
+++ b/app/src/main/java/io/embrace/shoppingcart/data/repository/ProductRepositoryImpl.kt
@@ -3,25 +3,53 @@ package io.embrace.shoppingcart.data.repository
 import io.embrace.shoppingcart.data.local.ProductDao
 import io.embrace.shoppingcart.data.local.ProductEntity
 import io.embrace.shoppingcart.domain.model.Product
+import io.embrace.shoppingcart.mock.MockNetworkConfig
 import io.embrace.shoppingcart.network.ApiService
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 class ProductRepositoryImpl @Inject constructor(
     private val apiService: ApiService,
-    private val productDao: ProductDao
+    private val productDao: ProductDao,
+    private val networkConfig: MockNetworkConfig
 ) : ProductRepository {
     override suspend fun getProducts(): List<Product> {
-        val names = apiService.getProducts()
-        val entities = names.mapIndexed { index, name ->
-            ProductEntity(id = index.toString(), name = name, priceCents = (index + 1) * 1000)
+        delay(networkConfig.defaultDelayMs)
+        val products = apiService.getProducts()
+        val entities = products.map { dto ->
+            ProductEntity(
+                id = dto.id,
+                name = dto.name,
+                priceCents = dto.priceCents,
+                description = dto.description,
+                imageUrl = dto.imageUrl
+            )
         }
         productDao.upsertAll(entities)
-        return entities.map { Product(it.id, it.name, it.priceCents) }
+        return entities.map { entity ->
+            Product(
+                id = entity.id,
+                name = entity.name,
+                priceCents = entity.priceCents,
+                description = entity.description,
+                imageUrl = entity.imageUrl
+            )
+        }
     }
 
     override fun observeProducts() =
-        productDao.observeAll().map { list -> list.map { Product(it.id, it.name, it.priceCents) } }
+        productDao.observeAll().map { list ->
+            list.map { entity ->
+                Product(
+                    id = entity.id,
+                    name = entity.name,
+                    priceCents = entity.priceCents,
+                    description = entity.description,
+                    imageUrl = entity.imageUrl
+                )
+            }
+        }
 }
 
 

--- a/app/src/main/java/io/embrace/shoppingcart/di/MockModule.kt
+++ b/app/src/main/java/io/embrace/shoppingcart/di/MockModule.kt
@@ -1,0 +1,21 @@
+package io.embrace.shoppingcart.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import io.embrace.shoppingcart.mock.AuthConfig
+import io.embrace.shoppingcart.mock.MockAuthService
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object MockModule {
+    @Provides
+    @Singleton
+    fun provideAuthConfig(): AuthConfig = AuthConfig()
+
+    @Provides
+    @Singleton
+    fun provideMockAuthService(config: AuthConfig): MockAuthService = MockAuthService(config)
+}

--- a/app/src/main/java/io/embrace/shoppingcart/di/NetworkModule.kt
+++ b/app/src/main/java/io/embrace/shoppingcart/di/NetworkModule.kt
@@ -1,11 +1,14 @@
 package io.embrace.shoppingcart.di
 
 import com.squareup.moshi.Moshi
+import android.content.Context
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import io.embrace.shoppingcart.mock.MockApiService
+import io.embrace.shoppingcart.mock.MockNetworkConfig
 import io.embrace.shoppingcart.network.ApiService
 import javax.inject.Singleton
 import okhttp3.OkHttpClient
@@ -41,5 +44,16 @@ object NetworkModule {
     fun provideRealApiService(retrofit: Retrofit): ApiService =
             retrofit.create(ApiService::class.java)
 
-    @Provides @Singleton @MockApi fun provideMockApiService(): ApiService = MockApiService()
+    @Provides
+    @Singleton
+    fun provideMockNetworkConfig(): MockNetworkConfig = MockNetworkConfig()
+
+    @Provides
+    @Singleton
+    @MockApi
+    fun provideMockApiService(
+        @ApplicationContext context: Context,
+        moshi: Moshi,
+        config: MockNetworkConfig
+    ): ApiService = MockApiService(context, moshi, config)
 }

--- a/app/src/main/java/io/embrace/shoppingcart/mock/MockApiService.kt
+++ b/app/src/main/java/io/embrace/shoppingcart/mock/MockApiService.kt
@@ -1,14 +1,43 @@
 package io.embrace.shoppingcart.mock
 
+import android.content.Context
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
 import io.embrace.shoppingcart.network.ApiService
+import io.embrace.shoppingcart.network.ProductDto
+import kotlinx.coroutines.delay
+import java.io.IOException
+import javax.inject.Inject
 
-class MockApiService : ApiService {
-    override suspend fun getProducts(): List<String> = listOf(
-        "Camiseta",
-        "Pantalón",
-        "Zapatillas",
-        "Gorra"
+class MockApiService @Inject constructor(
+    private val context: Context,
+    private val moshi: Moshi,
+    private val config: MockNetworkConfig
+) : ApiService {
+
+    private val adapter = moshi.adapter<List<ProductDto>>(
+        Types.newParameterizedType(List::class.java, ProductDto::class.java)
     )
+
+    override suspend fun getProducts(): List<ProductDto> {
+        return when (config.scenario) {
+            NetworkScenario.SUCCESS -> {
+                delay(config.defaultDelayMs)
+                loadProducts()
+            }
+            NetworkScenario.FAILURE -> {
+                delay(config.defaultDelayMs)
+                throw IOException("Simulated network failure")
+            }
+            NetworkScenario.SLOW -> {
+                delay(config.slowDelayMs)
+                loadProducts()
+            }
+        }
+    }
+
+    private fun loadProducts(): List<ProductDto> {
+        val json = context.assets.open("products.json").bufferedReader().use { it.readText() }
+        return adapter.fromJson(json) ?: emptyList()
+    }
 }
-
-

--- a/app/src/main/java/io/embrace/shoppingcart/mock/MockAuthService.kt
+++ b/app/src/main/java/io/embrace/shoppingcart/mock/MockAuthService.kt
@@ -1,0 +1,36 @@
+package io.embrace.shoppingcart.mock
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+sealed class AuthState {
+    object LoggedOut : AuthState()
+    data class LoggedIn(val userId: String) : AuthState()
+}
+
+data class AuthConfig(
+    val delayMs: Long = 0L,
+    val failLogin: Boolean = false
+)
+
+@Singleton
+class MockAuthService @Inject constructor(
+    private val config: AuthConfig
+) {
+    private val _state = MutableStateFlow<AuthState>(AuthState.LoggedOut)
+    val state: StateFlow<AuthState> = _state
+
+    suspend fun login(userId: String) {
+        delay(config.delayMs)
+        if (config.failLogin) throw IllegalStateException("Login failed")
+        _state.value = AuthState.LoggedIn(userId)
+    }
+
+    suspend fun logout() {
+        delay(config.delayMs)
+        _state.value = AuthState.LoggedOut
+    }
+}

--- a/app/src/main/java/io/embrace/shoppingcart/mock/MockNetworkConfig.kt
+++ b/app/src/main/java/io/embrace/shoppingcart/mock/MockNetworkConfig.kt
@@ -1,0 +1,9 @@
+package io.embrace.shoppingcart.mock
+
+enum class NetworkScenario { SUCCESS, FAILURE, SLOW }
+
+data class MockNetworkConfig(
+    val defaultDelayMs: Long = 0L,
+    val slowDelayMs: Long = 3000L,
+    val scenario: NetworkScenario = NetworkScenario.SUCCESS
+)

--- a/app/src/main/java/io/embrace/shoppingcart/network/ApiService.kt
+++ b/app/src/main/java/io/embrace/shoppingcart/network/ApiService.kt
@@ -4,7 +4,7 @@ import retrofit2.http.GET
 
 interface ApiService {
     @GET("products")
-    suspend fun getProducts(): List<String>
+    suspend fun getProducts(): List<ProductDto>
 }
 
 

--- a/app/src/main/java/io/embrace/shoppingcart/network/ProductDto.kt
+++ b/app/src/main/java/io/embrace/shoppingcart/network/ProductDto.kt
@@ -1,11 +1,9 @@
-package io.embrace.shoppingcart.domain.model
+package io.embrace.shoppingcart.network
 
-data class Product(
+data class ProductDto(
     val id: String,
     val name: String,
     val priceCents: Int,
     val description: String,
     val imageUrl: String
 )
-
-


### PR DESCRIPTION
## Summary
- add local products.json asset for catalog data
- introduce configurable MockApiService supporting success/failure/slow scenarios
- add MockAuthService to manage authentication states
- persist description and image URL fields through ProductRepository

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a44ca5af88333915f6bba91531aa0