### PR TITLE
Add Compose previews and system bar padding to activities

### DIFF
--- a/app/src/main/java/io/embrace/shoppingcart/MainActivity.kt
+++ b/app/src/main/java/io/embrace/shoppingcart/MainActivity.kt
@@ -6,8 +6,12 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.material3.Scaffold
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.runtime.Composable
 import dagger.hilt.android.AndroidEntryPoint
 import io.embrace.shoppingcart.presentation.main.MainActionsScreen
 import io.embrace.shoppingcart.ui.theme.EmbraceShoppingCartTheme
@@ -19,10 +23,26 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             EmbraceShoppingCartTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
+                Scaffold(
+                    modifier = Modifier.fillMaxSize(),
+                    contentWindowInsets = WindowInsets.systemBars
+                ) { innerPadding ->
                     MainActionsScreen(modifier = Modifier.padding(innerPadding))
                 }
             }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun MainActivityPreview() {
+    EmbraceShoppingCartTheme {
+        Scaffold(
+            modifier = Modifier.fillMaxSize(),
+            contentWindowInsets = WindowInsets.systemBars
+        ) { innerPadding ->
+            MainActionsScreen(modifier = Modifier.padding(innerPadding))
         }
     }
 }

--- a/app/src/main/java/io/embrace/shoppingcart/ui/checkout/CheckoutActivity.kt
+++ b/app/src/main/java/io/embrace/shoppingcart/ui/checkout/CheckoutActivity.kt
@@ -3,10 +3,16 @@ package io.embrace.shoppingcart.ui.checkout
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.runtime.Composable
 import dagger.hilt.android.AndroidEntryPoint
 import io.embrace.shoppingcart.ui.theme.EmbraceShoppingCartTheme
 
@@ -14,12 +20,35 @@ import io.embrace.shoppingcart.ui.theme.EmbraceShoppingCartTheme
 class CheckoutActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         setContent {
             EmbraceShoppingCartTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) {
-                    Text(text = "Checkout")
+                Scaffold(
+                    modifier = Modifier.fillMaxSize(),
+                    contentWindowInsets = WindowInsets.systemBars
+                ) { innerPadding ->
+                    Text(
+                        text = "Checkout",
+                        modifier = Modifier.padding(innerPadding)
+                    )
                 }
             }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun CheckoutActivityPreview() {
+    EmbraceShoppingCartTheme {
+        Scaffold(
+            modifier = Modifier.fillMaxSize(),
+            contentWindowInsets = WindowInsets.systemBars
+        ) { innerPadding ->
+            Text(
+                text = "Checkout",
+                modifier = Modifier.padding(innerPadding)
+            )
         }
     }
 }

--- a/app/src/main/java/io/embrace/shoppingcart/ui/home/HomeActivity.kt
+++ b/app/src/main/java/io/embrace/shoppingcart/ui/home/HomeActivity.kt
@@ -3,9 +3,16 @@ package io.embrace.shoppingcart.ui.home
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.material3.Scaffold
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.runtime.Composable
 import dagger.hilt.android.AndroidEntryPoint
 import io.embrace.shoppingcart.presentation.home.HomeScreen
 import io.embrace.shoppingcart.ui.theme.EmbraceShoppingCartTheme
@@ -14,11 +21,32 @@ import io.embrace.shoppingcart.ui.theme.EmbraceShoppingCartTheme
 class HomeActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         setContent {
             EmbraceShoppingCartTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) {
-                    HomeScreen()
+                Scaffold(
+                    modifier = Modifier.fillMaxSize(),
+                    contentWindowInsets = WindowInsets.systemBars
+                ) { innerPadding ->
+                    Box(modifier = Modifier.padding(innerPadding)) {
+                        HomeScreen()
+                    }
                 }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun HomeActivityPreview() {
+    EmbraceShoppingCartTheme {
+        Scaffold(
+            modifier = Modifier.fillMaxSize(),
+            contentWindowInsets = WindowInsets.systemBars
+        ) { innerPadding ->
+            Box(modifier = Modifier.padding(innerPadding)) {
+                HomeScreen()
             }
         }
     }

--- a/app/src/main/java/io/embrace/shoppingcart/ui/product/ProductDetailActivity.kt
+++ b/app/src/main/java/io/embrace/shoppingcart/ui/product/ProductDetailActivity.kt
@@ -3,10 +3,16 @@ package io.embrace.shoppingcart.ui.product
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.runtime.Composable
 import dagger.hilt.android.AndroidEntryPoint
 import io.embrace.shoppingcart.ui.theme.EmbraceShoppingCartTheme
 
@@ -16,12 +22,35 @@ class ProductDetailActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         val productId = intent.getStringExtra("productId")
             ?: intent?.data?.getQueryParameter("id")
+        enableEdgeToEdge()
         setContent {
             EmbraceShoppingCartTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) {
-                    Text(text = "Product detail: ${'$'}productId")
+                Scaffold(
+                    modifier = Modifier.fillMaxSize(),
+                    contentWindowInsets = WindowInsets.systemBars
+                ) { innerPadding ->
+                    Text(
+                        text = "Product detail: ${'$'}productId",
+                        modifier = Modifier.padding(innerPadding)
+                    )
                 }
             }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun ProductDetailActivityPreview() {
+    EmbraceShoppingCartTheme {
+        Scaffold(
+            modifier = Modifier.fillMaxSize(),
+            contentWindowInsets = WindowInsets.systemBars
+        ) { innerPadding ->
+            Text(
+                text = "Product detail: 123",
+                modifier = Modifier.padding(innerPadding)
+            )
         }
     }
 }

--- a/app/src/main/java/io/embrace/shoppingcart/ui/profile/ProfileActivity.kt
+++ b/app/src/main/java/io/embrace/shoppingcart/ui/profile/ProfileActivity.kt
@@ -3,10 +3,16 @@ package io.embrace.shoppingcart.ui.profile
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.runtime.Composable
 import dagger.hilt.android.AndroidEntryPoint
 import io.embrace.shoppingcart.ui.theme.EmbraceShoppingCartTheme
 
@@ -14,12 +20,35 @@ import io.embrace.shoppingcart.ui.theme.EmbraceShoppingCartTheme
 class ProfileActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         setContent {
             EmbraceShoppingCartTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) {
-                    Text(text = "Profile")
+                Scaffold(
+                    modifier = Modifier.fillMaxSize(),
+                    contentWindowInsets = WindowInsets.systemBars
+                ) { innerPadding ->
+                    Text(
+                        text = "Profile",
+                        modifier = Modifier.padding(innerPadding)
+                    )
                 }
             }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun ProfileActivityPreview() {
+    EmbraceShoppingCartTheme {
+        Scaffold(
+            modifier = Modifier.fillMaxSize(),
+            contentWindowInsets = WindowInsets.systemBars
+        ) { innerPadding ->
+            Text(
+                text = "Profile",
+                modifier = Modifier.padding(innerPadding)
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- add Compose previews for Main, Home, ProductDetail, Profile, and Checkout activities
- apply system bar padding and enable edge-to-edge in all activities

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b8590e5ec8333a45f1b3baaa77aa3