### PR TITLE
Add Moshi Kotlin adapter

### DIFF
--- a/app/src/main/java/io/embrace/shoppingcart/di/NetworkModule.kt
+++ b/app/src/main/java/io/embrace/shoppingcart/di/NetworkModule.kt
@@ -1,6 +1,7 @@
 package io.embrace.shoppingcart.di
 
 import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import android.content.Context
 import dagger.Module
 import dagger.Provides
@@ -27,7 +28,11 @@ object NetworkModule {
         return OkHttpClient.Builder().addInterceptor(logging).build()
     }
 
-    @Provides @Singleton fun provideMoshi(): Moshi = Moshi.Builder().build()
+    @Provides
+    @Singleton
+    fun provideMoshi(): Moshi = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
 
     @Provides
     @Singleton


### PR DESCRIPTION
## Summary
- ensure Moshi supports Kotlin types by adding KotlinJsonAdapterFactory

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b8974cd608333b1690b4683870d52